### PR TITLE
Notifications for RFCs scheduled this Sunday

### DIFF
--- a/notifications/10-14-21-1100.md
+++ b/notifications/10-14-21-1100.md
@@ -1,0 +1,23 @@
+**What is happening?**
+CHG0030317 - STMS NET - F5 load balancer upgrade Interior Silver MCS
+
+This is standard maintaince applied to our F5 instances and this one will be for the F5 instance servicing the SILVER Openshift cluster. Maintenance is performed in a highly available manner (one F5 instance is upgraded while the other instance handles all traffic), but a temporary network disconnect may be experienced for open connections during fail-over events - a refresh of the network connection will address this.
+
+**When?**
+
+This Sunday morning (October 17th 2021) after 6am PDT.
+
+**Will there be an impact on the Platform apps?**
+
+A small disruption to open network connections may occur during an F5 fail-over event while maintenance takes place. A refresh of the network connection between the source (web browser/another app/etc) will restore this if lost. There will be no disruption to pod or cluster uptime during this maintenance.
+
+**Do I need to do anything?**
+
+Check the #devops-alert channel for the announcement of when the change is complete and check the health of your app.
+
+**Where do I get help if my app doesn't work after the change is complete?**
+
+Each Platform application has an assigned DevOps Specialist within the Ministry so contact them first. If you don't know who your assigned DevOps Specialist, check with the app's Product Owner.
+
+The DevOps Specialist will troubleshoot the issue with the app and if they need help, they will reach out to the Platform Services Team and the Developer Community in Rocket.Chat as per these [RocketChat Channel Use Guidelines](
+https://developer.gov.bc.ca/Getting-human-support-for-issues-not-covered-by-devops-requests).

--- a/notifications/10-14-21-1200.md
+++ b/notifications/10-14-21-1200.md
@@ -1,0 +1,28 @@
+**What is happening?**
+CHG0030292 MCS - NetApp Storage iSCSI Configuration - SILVER
+
+The DXC Storage team has identified an issue in the production NetApp setups that limits the redundancy of iSCSI connections between the app nodes and the NetApp. This will migrate one of the iSCSI connections to the secondary network switch so that a switch failure will not take out both iSCSI connections and multipath access.
+
+This configuration change only involves NetApp block PVC storage. NetApp file PVC storage does not use iSCSI. Storage to running pods will not be affected. If starting up a new pod with block storage during the maintenance activity and it does not work, reattempt the activity after maintenance is completed.
+
+This change was also required for the GOLD cluster and previously made successfully with no issues.
+
+
+**When?**
+
+This Sunday morning (October 17th 2021) after 9am PDT.
+
+**Will there be an impact on the Platform apps?**
+
+No impact to running pods, a loss of redundancy for block PVCs while the NetApp configuration change is made which is then restored once the change is complete.
+
+**Do I need to do anything?**
+
+Check the #devops-alert channel for the announcement of when the change is complete and check the health of your app.
+
+**Where do I get help if my app doesn't work after the change is complete?**
+
+Each Platform application has an assigned DevOps Specialist within the Ministry so contact them first. If you don't know who your assigned DevOps Specialist, check with the app's Product Owner.
+
+The DevOps Specialist will troubleshoot the issue with the app and if they need help, they will reach out to the Platform Services Team and the Developer Community in Rocket.Chat as per these [RocketChat Channel Use Guidelines](
+https://developer.gov.bc.ca/Getting-human-support-for-issues-not-covered-by-devops-requests).


### PR DESCRIPTION
Two notification files (one per RFC). Aiming to post in RC alerts channel before end of day Thursday to ensure proper notification reaches out to all parties including those who may be on flex tomorrow.